### PR TITLE
Suppress clang pragma warnings

### DIFF
--- a/src/crypto/cn_heavy_hash.hpp
+++ b/src/crypto/cn_heavy_hash.hpp
@@ -61,7 +61,9 @@
 #endif
 
 #if defined(__aarch64__)
+#ifndef __clang__
 #pragma GCC target ("+crypto")
+#endif
 #include <sys/auxv.h>
 #include <asm/hwcap.h>
 #include <arm_neon.h>


### PR DESCRIPTION
When building all archs for android wallet